### PR TITLE
Fix session name truncation to prevent overlap with close button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,10 @@
     opacity: 1;
   }
 
+  .session-name-container {
+    min-width: 0;
+  }
+
   .session-name-text {
     cursor: pointer;
   }


### PR DESCRIPTION
Added min-width: 0 to session-name-container to allow flex children to shrink below their content size, enabling proper text truncation when session names are long.