### PR TITLE
Clear MCP sidebar when switching between sessions

### DIFF
--- a/renderer.ts
+++ b/renderer.ts
@@ -525,6 +525,10 @@ function switchToSession(sessionId: string) {
       mcpSection.style.display = "block";
     }
 
+    // Clear MCP servers from previous session and re-render
+    mcpServers = [];
+    renderMcpServers();
+
     // Load MCP servers for this session
     loadMcpServers();
 


### PR DESCRIPTION
Fixes issue where MCP servers from previous session would remain visible in sidebar until new session's servers loaded.