### PR TITLE
Add worktree path display to session sidebar

### DIFF
--- a/renderer.ts
+++ b/renderer.ts
@@ -329,14 +329,20 @@ function addToSidebar(sessionId: string, name: string, hasActivePty: boolean) {
   const list = document.getElementById("session-list");
   if (!list) return;
 
+  const session = sessions.get(sessionId);
+  const worktreePath = session?.worktreePath || '';
+
   const item = document.createElement("div");
   item.id = `sidebar-${sessionId}`;
   item.className = "session-list-item";
   item.innerHTML = `
     <div class="flex items-center space-x-2 flex-1 session-name-container">
       <span class="session-indicator ${hasActivePty ? 'active' : ''}"></span>
-      <span class="truncate session-name-text" data-id="${sessionId}">${name}</span>
-      <input type="text" class="session-name-input hidden" data-id="${sessionId}" value="${name}" />
+      <div class="flex-1 min-w-0">
+        <span class="truncate session-name-text block" data-id="${sessionId}">${name}</span>
+        <input type="text" class="session-name-input hidden" data-id="${sessionId}" value="${name}" />
+        <span class="session-worktree-path text-xs text-gray-500 truncate block">${worktreePath}</span>
+      </div>
     </div>
     <button class="session-delete-btn" data-id="${sessionId}" title="Delete session">×</button>
   `;

--- a/styles.css
+++ b/styles.css
@@ -100,6 +100,10 @@
     min-width: 80px;
   }
 
+  .session-worktree-path {
+    @apply text-xs text-gray-500 truncate block mt-0.5;
+  }
+
   /* Tabs */
   .tabs-container {
     @apply flex bg-gray-900 border-b border-gray-700 overflow-x-auto;


### PR DESCRIPTION
## Summary
- Displays the worktree directory path below each session name in the sidebar
- Uses subtle gray text styling to provide context without cluttering the UI
- Helps users quickly identify where each session's files are located

## Test plan
- [x] Create a new session and verify the worktree path appears below the session name
- [x] Verify the path is truncated appropriately if too long
- [x] Verify the styling is subtle and doesn't interfere with existing UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)