### PR TITLE
Add worktree path display to session sidebar

### DIFF
--- a/renderer.ts
+++ b/renderer.ts
@@ -341,7 +341,7 @@ function addToSidebar(sessionId: string, name: string, hasActivePty: boolean) {
       <div class="flex-1 min-w-0">
         <span class="truncate session-name-text block" data-id="${sessionId}">${name}</span>
         <input type="text" class="session-name-input hidden" data-id="${sessionId}" value="${name}" />
-        <span class="session-worktree-path text-xs text-gray-500 truncate block">${worktreePath}</span>
+        <span class="session-worktree-path text-xs text-gray-500 block break-all">${worktreePath}</span>
       </div>
     </div>
     <button class="session-delete-btn" data-id="${sessionId}" title="Delete session">×</button>

--- a/styles.css
+++ b/styles.css
@@ -101,7 +101,8 @@
   }
 
   .session-worktree-path {
-    @apply text-xs text-gray-500 truncate block mt-0.5;
+    @apply text-xs text-gray-500 block mt-0.5;
+    word-break: break-all;
   }
 
   /* Tabs */


### PR DESCRIPTION
## Summary
- Displays the worktree directory path below each session name in the sidebar
- Uses subtle gray text styling to provide context without cluttering the UI
- Session name truncates if too long, but worktree path wraps across multiple lines to show the full path
- Helps users quickly identify where each session's files are located

## Test plan
- [x] Create a new session and verify the worktree path appears below the session name
- [x] Verify the path wraps to multiple lines and displays the full path
- [x] Verify the session name still truncates appropriately
- [x] Verify the styling is subtle and doesn't interfere with existing UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)