### PR TITLE
Fix MCP regex to handle SSE connection failures

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -144,8 +144,8 @@ function spawnMcpPoller(sessionId: string, projectDir: string) {
 
     // Parse output whenever we have MCP server entries
     // Match lines like: "servername: url (type) - ✓ Connected" or "servername: command (stdio) - ✓ Connected"
-    // Pattern handles SSE, stdio, and HTTP types
-    const mcpServerLineRegex = /^[\w-]+:.+\((?:SSE|stdio|HTTP)\)\s+-\s+[✓⚠]/m;
+    // Pattern handles SSE, stdio, and HTTP types (case-insensitive) with success (✓), warning (⚠), or failure (✗) status
+    const mcpServerLineRegex = /^[\w-]+:.+\((?:SSE|sse|stdio|HTTP)\)\s+-\s+[✓⚠✗]/mi;
 
     if (mcpServerLineRegex.test(data) || data.includes("No MCP servers configured")) {
       try {
@@ -217,7 +217,7 @@ function parseMcpOutput(output: string): any[] {
 
     // Only parse lines that match the MCP server format
     // Must have: "name: something (SSE|stdio|HTTP) - status"
-    const serverMatch = line.match(/^([\w-]+):.+\((?:SSE|stdio|HTTP)\)\s+-\s+[✓⚠]/);
+    const serverMatch = line.match(/^([\w-]+):.+\((?:SSE|sse|stdio|HTTP)\)\s+-\s+[✓⚠✗]/i);
     if (serverMatch) {
       const serverName = serverMatch[1];
       const isConnected = line.includes("✓") || line.includes("Connected");


### PR DESCRIPTION
## Summary
- Updated MCP server regex patterns to recognize SSE connection failures
- Made SSE pattern matching case-insensitive
- Added support for failed connection status symbol (✗)

## Problem
The MCP server list parser was only matching servers with successful (✓) or warning (⚠) status. This caused SSE servers with failed connections to be ignored, as shown in:
```
jira: https://mcp.atlassian.com/v1/see (SSE) - ✗ Failed to connect
```

## Solution
Updated both regex patterns in `main.ts`:
1. Line 148: MCP server line detection regex
2. Line 220: Server parsing regex

Changes:
- Added `✗` symbol to the status character class
- Made pattern case-insensitive with `i` flag to handle "SSE", "sse", etc.
- Updated comments to reflect new behavior

## Test plan
- [ ] Verify failed SSE connections now appear in MCP server list
- [ ] Confirm status indicator shows disconnected state
- [ ] Test with various case combinations (SSE, sse, Sse)