### PR TITLE
Improve unread indicator detection and add terminal logging

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -9,6 +9,7 @@ import {simpleGit} from "simple-git";
 import {promisify} from "util";
 import {v4 as uuidv4} from "uuid";
 import {PersistedSession, SessionConfig} from "./types";
+import {isTerminalReady} from "./terminal-utils";
 
 const execAsync = promisify(exec);
 
@@ -29,12 +30,6 @@ function getWorktreeBaseDir(): string {
     return settings.worktreeDir;
   }
   return path.join(os.homedir(), "worktrees");
-}
-
-function isTerminalReady(buffer: string, startPos: number = 0): boolean {
-  const searchBuffer = buffer.slice(startPos);
-
-  return searchBuffer.includes("\x1b[?2004h", startPos);
 }
 
 function savePersistedSessions(sessions: PersistedSession[]) {
@@ -139,6 +134,7 @@ function spawnMcpPoller(sessionId: string, projectDir: string) {
   const serverMap = new Map<string, any>();
 
   ptyProcess.onData((data) => {
+
     // Accumulate output without displaying it
     outputBuffer += data;
 
@@ -469,6 +465,7 @@ ipcMain.on("create-session", async (event, config: SessionConfig) => {
 // Handle session input
 ipcMain.on("session-input", (_event, sessionId: string, data: string) => {
   const ptyProcess = activePtyProcesses.get(sessionId);
+
   if (ptyProcess) {
     ptyProcess.write(data);
   }
@@ -508,6 +505,7 @@ ipcMain.on("reopen-session", (event, sessionId: string) => {
 // Close session (kill PTY but keep session)
 ipcMain.on("close-session", (_event, sessionId: string) => {
   const ptyProcess = activePtyProcesses.get(sessionId);
+
   if (ptyProcess) {
     ptyProcess.kill();
     activePtyProcesses.delete(sessionId);

--- a/terminal-utils.ts
+++ b/terminal-utils.ts
@@ -1,0 +1,20 @@
+// Terminal escape sequences used for detecting terminal state
+
+// Bracketed paste mode enable - indicates terminal is ready for input
+export const BRACKETED_PASTE_MODE_ENABLE = "\x1b[?2004h";
+
+// Pattern that indicates Claude interactive session is done and waiting for input
+// Looks for: >\r\n (empty prompt with no space, no suggestion text)
+const CLAUDE_READY_PROMPT_PATTERN = />\r\n/;
+
+// Check if a normal shell terminal is ready for input
+// Used during terminal initialization in main.ts
+export function isTerminalReady(buffer: string, startPos: number = 0): boolean {
+  return buffer.includes(BRACKETED_PASTE_MODE_ENABLE, startPos);
+}
+
+// Check if Claude interactive session is done and ready for input
+// Used for unread indicator detection in renderer.ts
+export function isClaudeSessionReady(buffer: string): boolean {
+  return CLAUDE_READY_PROMPT_PATTERN.test(buffer);
+}


### PR DESCRIPTION
## Summary
- Fixed unread indicator detection to only trigger when Claude finishes responding (using `>\r\n` pattern instead of timer-based detection)
- Separated terminal ready detection logic for shell initialization vs Claude interactive session completion

## Changes
- **terminal-utils.ts**: New shared utilities for terminal state detection with `isTerminalReady()` (shell) and `isClaudeSessionReady()` (Claude interactive)
- **main.ts**: Updated to use `isTerminalReady()` for shell initialization
- **renderer.ts**: Updated unread detection to use `isClaudeSessionReady()` and removed timer-based detection logic

## Test plan
- [ ] Create a new session and verify unread indicator only triggers after Claude finishes responding (not immediately on command submission)
- [ ] Test with multiple sessions to ensure unread detection works correctly for each session
- [ ] Verify terminal initialization still works properly