### PR TITLE
Add branch name validation for worktree creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,8 @@
         <div class="form-group" id="branch-name-group">
           <label class="form-label">Branch Name (optional)</label>
           <input type="text" id="branch-name" class="form-input" placeholder="e.g., feature/add-login" />
-          <span class="text-xs text-gray-400 mt-1 block">Custom branch name for worktree (will also be used as session name)</span>
+          <span id="branch-name-error" class="text-xs text-red-400 mt-1 hidden">Branch already exists</span>
+          <span id="branch-name-help" class="text-xs text-gray-400 mt-1 block">Custom branch name for worktree (will also be used as session name)</span>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
## Summary
- Adds real-time validation when creating worktrees to prevent duplicate branch names
- Shows red error text "Branch already exists" when user enters an existing branch name
- Validates against both local and remote branches
- Prevents worktree creation if branch name conflicts with existing branches

## Changes
- Added error message element in the branch name input field
- Implemented `validateBranchName()` function to check against existing branches
- Added input event listener for real-time validation
- Added validation check before worktree creation
- Reset validation state when modal is closed or session created

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Manual testing: Try creating a worktree with an existing branch name and verify error appears
- [x] Manual testing: Verify error clears when valid branch name is entered
- [x] Manual testing: Verify creation is blocked when branch exists