### PR TITLE
Fix settings modal button sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -155,7 +155,7 @@
 
   /* Button */
   .btn-primary {
-    @apply w-full bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded text-sm font-medium transition;
+    @apply bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded text-sm font-medium transition;
   }
 
   /* Session Container */


### PR DESCRIPTION
## Summary
- Removed full-width styling from primary buttons in the settings modal
- Buttons now size appropriately based on their content instead of stretching to fill the entire container width

## Changes
- Removed `w-full` class from `.btn-primary` in `styles.css`

## Test plan
- Open the settings modal and verify buttons (Cancel, Reset to Default, Save) are appropriately sized
- Verify buttons still function correctly
- Check other modals to ensure button styling is consistent