### PR TITLE
Update delete session dialog for local sessions

### DIFF
--- a/renderer.ts
+++ b/renderer.ts
@@ -696,8 +696,13 @@ function deleteSession(sessionId: string) {
   const session = sessions.get(sessionId);
   if (!session) return;
 
-  // Confirm deletion
-  if (!confirm(`Delete ${session.name}? This will remove the git worktree.`)) {
+  // Confirm deletion with different message based on session type
+  const isWorktree = session.config.sessionType === SessionType.WORKTREE;
+  const message = isWorktree
+    ? `Delete ${session.name}? This will remove the git worktree.`
+    : `Delete ${session.name}? This will remove the session.`;
+
+  if (!confirm(message)) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- Show different confirmation messages when deleting sessions based on session type
- Worktree sessions: "Delete {name}? This will remove the git worktree."
- Local sessions: "Delete {name}? This will remove the session."

## Test plan
- [ ] Create a local session and verify the delete dialog shows "This will remove the session."
- [ ] Create a worktree session and verify the delete dialog shows "This will remove the git worktree."

🤖 Generated with [Claude Code](https://claude.com/claude-code)